### PR TITLE
Improve carousel responsiveness

### DIFF
--- a/src/Carousel.css
+++ b/src/Carousel.css
@@ -1,6 +1,7 @@
 .carousel-container {
   position: relative;
-  width: 371px;
+  width: 80vw;
+  max-width: 800px;
   height: 116px;
   overflow: hidden;
   margin: 20px auto;
@@ -12,8 +13,6 @@
 }
 
 .carousel-item {
-  flex: 0 0 371px;
-  width: 371px;
   height: 116px;
   display: flex;
   align-items: center;

--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import './Carousel.css';
 
 type CarouselProps = {
@@ -7,19 +7,41 @@ type CarouselProps = {
 
 const Carousel: React.FC<CarouselProps> = ({ items }) => {
   const [index, setIndex] = useState(0);
+  const [slidesPerView, setSlidesPerView] = useState(
+    typeof window !== 'undefined' && window.innerWidth > 1200 ? 2 : 1
+  );
+
+  useEffect(() => {
+    const handleResize = () => {
+      setSlidesPerView(window.innerWidth > 1200 ? 2 : 1);
+      setIndex(0);
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
   const next = () => {
-    setIndex((prev) => (prev + 1) % items.length);
+    setIndex((prev) => (prev + slidesPerView) % items.length);
   };
 
   return (
     <div className="carousel-container">
       <div
         className="carousel-inner"
-        style={{ transform: `translateX(-${index * 371}px)` }}
+        style={{
+          transform: `translateX(-${index * (100 / slidesPerView)}%)`,
+          width: `${(items.length * 100) / slidesPerView}%`,
+        }}
       >
         {items.map((item, i) => (
-          <div className="carousel-item" key={i}>
+          <div
+            className="carousel-item"
+            key={i}
+            style={{
+              flex: `0 0 ${100 / slidesPerView}%`,
+              width: `${100 / slidesPerView}%`,
+            }}
+          >
             {item}
           </div>
         ))}


### PR DESCRIPTION
## Summary
- make the Carousel component responsive
- support 1 or 2 slides depending on the viewport
- adjust CSS to size the carousel container responsively

## Testing
- `npm test --silent` *(fails: react-scripts not found)*