### PR TITLE
Add customizable carousel hook with navigation buttons

### DIFF
--- a/src/Carousel.css
+++ b/src/Carousel.css
@@ -23,3 +23,25 @@
   box-sizing: border-box;
 }
 
+.prev-button,
+.next-button {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: white;
+  border: 1px solid #ccc;
+  width: 30px;
+  height: 30px;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+}
+
+.prev-button {
+  left: 5px;
+}
+
+.next-button {
+  right: 5px;
+}
+

--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -1,21 +1,16 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import './Carousel.css';
+import useCarousel from './hooks/useCarousel';
 
 type CarouselProps = {
   items: React.ReactNode[];
+  autoPlay?: boolean;
+  delay?: number;
+  firstDelay?: number;
 };
 
-const Carousel: React.FC<CarouselProps> = ({ items }) => {
-  const [index, setIndex] = useState(0);
-
-  useEffect(() => {
-    const delay = index === 0 ? 5500 : 3500;
-    const timer = setTimeout(() => {
-      setIndex((prev) => (prev + 1) % items.length);
-    }, delay);
-
-    return () => clearTimeout(timer);
-  }, [index, items.length]);
+const Carousel: React.FC<CarouselProps> = ({ items, autoPlay = true, delay, firstDelay }) => {
+  const { index, next, prev } = useCarousel(items.length, { autoPlay, delay, firstDelay });
 
   return (
     <div className="carousel-container">
@@ -29,6 +24,12 @@ const Carousel: React.FC<CarouselProps> = ({ items }) => {
           </div>
         ))}
       </div>
+      <button className="prev-button" onClick={prev} aria-label="Previous">
+        ‹
+      </button>
+      <button className="next-button" onClick={next} aria-label="Next">
+        ›
+      </button>
     </div>
   );
 };

--- a/src/hooks/useCarousel.ts
+++ b/src/hooks/useCarousel.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect, useRef } from 'react';
+
+export type UseCarouselOptions = {
+  autoPlay?: boolean;
+  initialIndex?: number;
+  delay?: number;
+  firstDelay?: number;
+};
+
+function useCarousel(
+  length: number,
+  {
+    autoPlay = true,
+    initialIndex = 0,
+    delay = 3500,
+    firstDelay = 5500,
+  }: UseCarouselOptions = {}
+) {
+  const [index, setIndex] = useState(initialIndex);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const next = () => setIndex((i) => (i + 1) % length);
+  const prev = () => setIndex((i) => (i - 1 + length) % length);
+
+  useEffect(() => {
+    if (!autoPlay) {
+      return;
+    }
+
+    const timeoutDelay = index === 0 ? firstDelay : delay;
+    timerRef.current = setTimeout(next, timeoutDelay);
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [index, autoPlay, delay, firstDelay, length]);
+
+  return { index, next, prev, setIndex };
+}
+
+export default useCarousel;


### PR DESCRIPTION
## Summary
- introduce `useCarousel` hook for extendable auto-scrolling logic
- refactor `Carousel` component to use the hook
- restore next/previous buttons and styling

## Testing
- `npm test` *(fails: react-scripts not found)*