### PR TITLE
Add visibleCards prop to Carousel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ function App() {
 
   return (
     <div className="App">
-      <Carousel items={items.map((text) => <div>{text}</div>)} />
+      <Carousel items={items.map((text) => <div>{text}</div>)} visibleCards={2} />
     </div>
   );
 }

--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -7,16 +7,33 @@ type CarouselProps = {
   autoPlay?: boolean;
   delay?: number;
   firstDelay?: number;
+  visibleCards?: number;
 };
 
-const Carousel: React.FC<CarouselProps> = ({ items, autoPlay = true, delay, firstDelay }) => {
-  const { index, next, prev } = useCarousel(items.length, { autoPlay, delay, firstDelay });
+const cardWidth = 371;
+
+const Carousel: React.FC<CarouselProps> = ({
+  items,
+  autoPlay = true,
+  delay,
+  firstDelay,
+  visibleCards = 1,
+}) => {
+  const positions = Math.max(items.length - visibleCards + 1, 1);
+  const { index, next, prev } = useCarousel(positions, {
+    autoPlay,
+    delay,
+    firstDelay,
+  });
 
   return (
-    <div className="carousel-container">
+    <div
+      className="carousel-container"
+      style={{ width: `${cardWidth * visibleCards}px` }}
+    >
       <div
         className="carousel-inner"
-        style={{ transform: `translateX(-${index * 371}px)` }}
+        style={{ transform: `translateX(-${index * cardWidth}px)` }}
       >
         {items.map((item, i) => (
           <div className="carousel-item" key={i}>


### PR DESCRIPTION
## Summary
- allow specifying visible cards for Carousel
- show 2 cards in the example App

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*