### PR TITLE
Add Apollo Client with rate limiting link

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "@apollo/client": "^3.9.0",
+    "graphql": "^16.8.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import './App.css';
 import Carousel from './Carousel';
+import CountryList from './CountryList';
 
 function App() {
   const items = [
@@ -14,6 +15,7 @@ function App() {
   return (
     <div className="App">
       <Carousel items={items.map((text) => <div>{text}</div>)} visibleCards={2} />
+      <CountryList />
     </div>
   );
 }

--- a/src/CountryList.tsx
+++ b/src/CountryList.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { gql, useQuery } from '@apollo/client';
+
+const COUNTRIES_QUERY = gql`
+  query Countries {
+    countries {
+      code
+      name
+      emoji
+    }
+  }
+`;
+
+const CountryList: React.FC = () => {
+  const { data, loading, error } = useQuery(COUNTRIES_QUERY);
+
+  if (loading) return <p>Loading countries...</p>;
+  if (error) return <p>Error: {error.message}</p>;
+
+  return (
+    <ul>
+      {data.countries.map((c: { code: string; name: string; emoji: string }) => (
+        <li key={c.code}>
+          {c.emoji} {c.name}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default CountryList;

--- a/src/RateLimitLink.ts
+++ b/src/RateLimitLink.ts
@@ -1,0 +1,42 @@
+import { ApolloLink, Observable, Operation, NextLink } from '@apollo/client';
+
+/**
+ * Simple rate limiting link that allows `limit` operations per `interval`.
+ * Additional requests are queued and executed when tokens refill.
+ */
+export default class RateLimitLink extends ApolloLink {
+  private tokens: number;
+  private queue: Array<{
+    operation: Operation;
+    forward: NextLink;
+    observer: ZenObservable.Observer<any>;
+  }> = [];
+
+  constructor(private limit: number, private interval: number) {
+    super();
+    this.tokens = limit;
+    setInterval(() => {
+      this.tokens = this.limit;
+      this.flush();
+    }, interval);
+  }
+
+  request(operation: Operation, forward: NextLink) {
+    return new Observable(observer => {
+      this.queue.push({ operation, forward, observer });
+      this.flush();
+    });
+  }
+
+  private flush() {
+    while (this.tokens > 0 && this.queue.length > 0) {
+      const { operation, forward, observer } = this.queue.shift()!;
+      this.tokens--;
+      forward(operation).subscribe({
+        next: value => observer.next?.(value),
+        error: err => observer.error?.(err),
+        complete: () => observer.complete?.(),
+      });
+    }
+  }
+}

--- a/src/apolloClient.ts
+++ b/src/apolloClient.ts
@@ -1,0 +1,14 @@
+import { ApolloClient, InMemoryCache, HttpLink } from '@apollo/client';
+import RateLimitLink from './RateLimitLink';
+
+const httpLink = new HttpLink({ uri: 'https://countries.trevorblades.com/' });
+
+// Allow one request per second
+const rateLimitLink = new RateLimitLink(1, 1000);
+
+const client = new ApolloClient({
+  link: rateLimitLink.concat(httpLink),
+  cache: new InMemoryCache(),
+});
+
+export default client;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,13 +3,17 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { ApolloProvider } from '@apollo/client';
+import client from './apolloClient';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <ApolloProvider client={client}>
+      <App />
+    </ApolloProvider>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- add Apollo Client and GraphQL dependencies
- create a rate limiting Apollo link
- configure Apollo Client using the custom link
- fetch countries from a sample GraphQL API
- display results in App

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm install` *(fails: cannot fetch packages)*